### PR TITLE
feat: provide the color component instance as ColorWrap token

### DIFF
--- a/src/lib/components/alpha/alpha-picker.component.ts
+++ b/src/lib/components/alpha/alpha-picker.component.ts
@@ -1,11 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-  OnChanges,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule, OnChanges } from '@angular/core';
 
 import { AlphaModule, CheckboardModule, ColorWrap, toState } from 'ngx-color';
 
@@ -35,6 +29,12 @@ import { AlphaModule, CheckboardModule, ColorWrap, toState } from 'ngx-color';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => AlphaPickerComponent)
+    }
+  ]
 })
 export class AlphaPickerComponent extends ColorWrap implements OnChanges {
   /** Pixel value for picker width */

--- a/src/lib/components/block/block.component.ts
+++ b/src/lib/components/block/block.component.ts
@@ -1,18 +1,13 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 
 import {
   CheckboardModule,
   ColorWrap,
   EditableInputModule,
-  SwatchModule,
   getContrastingColor,
   isValidHex,
+  SwatchModule,
 } from 'ngx-color';
 import { BlockSwatchesComponent } from './block-swatches.component';
 
@@ -82,6 +77,12 @@ import { BlockSwatchesComponent } from './block-swatches.component';
   ],
   preserveWhitespaces: false,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => BlockComponent),
+    },
+  ],
 })
 export class BlockComponent extends ColorWrap {
   /** Pixel value for picker width */

--- a/src/lib/components/chrome/chrome.component.ts
+++ b/src/lib/components/chrome/chrome.component.ts
@@ -1,19 +1,7 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 
-import {
-  AlphaModule,
-  CheckboardModule,
-  ColorWrap,
-  EditableInputModule,
-  HueModule,
-  SaturationModule,
-} from 'ngx-color';
+import { AlphaModule, CheckboardModule, ColorWrap, EditableInputModule, HueModule, SaturationModule } from 'ngx-color';
 import { ChromeFieldsComponent } from './chrome-fields.component';
 
 @Component({
@@ -122,6 +110,12 @@ import { ChromeFieldsComponent } from './chrome-fields.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => ChromeComponent),
+    },
+  ],
 })
 export class ChromeComponent extends ColorWrap {
   /** Remove alpha slider and options from picker */

--- a/src/lib/components/circle/circle.component.ts
+++ b/src/lib/components/circle/circle.component.ts
@@ -1,10 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 import {
   amber,
   blue,
@@ -27,7 +22,7 @@ import {
 } from 'material-colors';
 import { TinyColor } from '@ctrl/tinycolor';
 
-import { ColorWrap, SwatchModule, isValidHex } from 'ngx-color';
+import { ColorWrap, isValidHex, SwatchModule } from 'ngx-color';
 import { CircleSwatchComponent } from './circle-swatch.component';
 
 @Component({
@@ -60,6 +55,12 @@ import { CircleSwatchComponent } from './circle-swatch.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => CircleComponent),
+    },
+  ],
 })
 export class CircleComponent extends ColorWrap {
   /** Pixel value for picker width */

--- a/src/lib/components/compact/compact.component.ts
+++ b/src/lib/components/compact/compact.component.ts
@@ -1,19 +1,7 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 
-import {
-  ColorWrap,
-  EditableInputModule,
-  RaisedModule,
-  SwatchModule,
-  isValidHex,
-  zDepth,
-} from 'ngx-color';
+import { ColorWrap, EditableInputModule, isValidHex, RaisedModule, SwatchModule, zDepth } from 'ngx-color';
 import { CompactColorComponent } from './compact-color.component';
 import { CompactFieldsComponent } from './compact-fields.component';
 
@@ -57,6 +45,12 @@ import { CompactFieldsComponent } from './compact-fields.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => CompactComponent),
+    },
+  ],
 })
 export class CompactComponent extends ColorWrap {
   /** Color squares to display */

--- a/src/lib/components/github/github.component.ts
+++ b/src/lib/components/github/github.component.ts
@@ -1,12 +1,7 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 
-import { ColorWrap, SwatchModule, isValidHex } from 'ngx-color';
+import { ColorWrap, isValidHex, SwatchModule } from 'ngx-color';
 import { GithubSwatchComponent } from './github-swatch.component';
 
 @Component({
@@ -87,6 +82,12 @@ import { GithubSwatchComponent } from './github-swatch.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => GithubComponent),
+    },
+  ],
 })
 export class GithubComponent extends ColorWrap {
   /** Pixel value for picker width */

--- a/src/lib/components/hue/hue-picker.component.ts
+++ b/src/lib/components/hue/hue-picker.component.ts
@@ -1,11 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-  OnChanges,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule, OnChanges } from '@angular/core';
 
 import { ColorWrap, HueModule, toState } from 'ngx-color';
 
@@ -30,6 +24,12 @@ import { ColorWrap, HueModule, toState } from 'ngx-color';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => HuePickerComponent),
+    },
+  ],
 })
 export class HuePickerComponent extends ColorWrap implements OnChanges {
   /** Pixel value for picker width */

--- a/src/lib/components/material/material.component.ts
+++ b/src/lib/components/material/material.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, NgModule, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 
-import { ColorWrap, EditableInputModule, RaisedModule, isValidHex, zDepth } from 'ngx-color';
+import { ColorWrap, EditableInputModule, isValidHex, RaisedModule, zDepth } from 'ngx-color';
 
 @Component({
   selector: 'color-material',
@@ -56,6 +56,12 @@ import { ColorWrap, EditableInputModule, RaisedModule, isValidHex, zDepth } from
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => MaterialComponent),
+    },
+  ],
 })
 export class MaterialComponent extends ColorWrap {
   HEXinput: {[key: string]: string} = {

--- a/src/lib/components/photoshop/photoshop.component.ts
+++ b/src/lib/components/photoshop/photoshop.component.ts
@@ -1,21 +1,7 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  NgModule,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, forwardRef, Input, NgModule, Output } from '@angular/core';
 
-import {
-  ColorWrap,
-  AlphaModule,
-  EditableInputModule,
-  HueModule,
-  SaturationModule,
-  SwatchModule,
-} from 'ngx-color';
+import { AlphaModule, ColorWrap, EditableInputModule, HueModule, SaturationModule, SwatchModule } from 'ngx-color';
 import { PhotoshopButtonComponent } from './photoshop-button.component';
 import { PhotoshopFieldsComponent } from './photoshop-fields.component';
 import { PhotoshopPreviewsComponent } from './photoshop-previews.component';
@@ -130,6 +116,12 @@ import { PhotoshopPreviewsComponent } from './photoshop-previews.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => PhotoshopComponent),
+    },
+  ],
 })
 export class PhotoshopComponent extends ColorWrap {
   /** Title text */

--- a/src/lib/components/shade/shade-picker.component.ts
+++ b/src/lib/components/shade/shade-picker.component.ts
@@ -1,11 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-  OnChanges,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule, OnChanges } from '@angular/core';
 import { ColorWrap, ShadeModule, toState } from 'ngx-color';
 
 @Component({
@@ -30,6 +24,12 @@ import { ColorWrap, ShadeModule, toState } from 'ngx-color';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => ShadeSliderComponent),
+    },
+  ],
 })
 export class ShadeSliderComponent extends ColorWrap implements OnChanges {
   /** Pixel value for picker width */

--- a/src/lib/components/sketch/sketch.component.ts
+++ b/src/lib/components/sketch/sketch.component.ts
@@ -1,10 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 
 import {
   AlphaModule,
@@ -12,9 +7,9 @@ import {
   ColorWrap,
   EditableInputModule,
   HueModule,
+  isValidHex,
   SaturationModule,
   SwatchModule,
-  isValidHex,
 } from 'ngx-color';
 import { SketchFieldsComponent } from './sketch-fields.component';
 import { SketchPresetColorsComponent } from './sketch-preset-colors.component';
@@ -129,6 +124,12 @@ import { SketchPresetColorsComponent } from './sketch-preset-colors.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => SketchComponent),
+    },
+  ],
 })
 export class SketchComponent extends ColorWrap {
   /** Remove alpha slider and options from picker */

--- a/src/lib/components/slider/slider.component.ts
+++ b/src/lib/components/slider/slider.component.ts
@@ -1,10 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 
 import { ColorWrap, HueModule, SwatchModule } from 'ngx-color';
 import { SliderSwatchComponent } from './slider-swatch.component';
@@ -37,6 +32,12 @@ import { SliderSwatchesComponent } from './slider-swatches.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => SliderComponent),
+    },
+  ],
 })
 export class SliderComponent extends ColorWrap {
   @Input()

--- a/src/lib/components/swatches/swatches.component.ts
+++ b/src/lib/components/swatches/swatches.component.ts
@@ -1,10 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  NgModule,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 import {
   amber,
   blue,
@@ -60,6 +55,12 @@ import { SwatchesGroupComponent } from './swatches-group.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => SwatchesComponent),
+    },
+  ],
 })
 export class SwatchesComponent extends ColorWrap {
   /** Pixel value for picker width */

--- a/src/lib/components/twitter/twitter.component.ts
+++ b/src/lib/components/twitter/twitter.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, NgModule } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, NgModule } from '@angular/core';
 
-import { ColorWrap, EditableInputModule, SwatchModule, isValidHex } from 'ngx-color';
+import { ColorWrap, EditableInputModule, isValidHex, SwatchModule } from 'ngx-color';
 
 @Component({
   selector: 'color-twitter',
@@ -124,6 +124,12 @@ import { ColorWrap, EditableInputModule, SwatchModule, isValidHex } from 'ngx-co
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   preserveWhitespaces: false,
+  providers: [
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => TwitterComponent),
+    },
+  ],
 })
 export class TwitterComponent extends ColorWrap {
   /** Pixel value for picker width */


### PR DESCRIPTION
Allows injecting the color component instance with a common injection token. For instance, a directive that should work with any color component and should have access to the current color component instance. With the common injection token, the directive can inject any color component instance with one injection statement.