### PR TITLE
feat: provide the color component instance as ColorWrap token

### DIFF
--- a/src/lib/components/alpha/alpha-picker.component.ts
+++ b/src/lib/components/alpha/alpha-picker.component.ts
@@ -35,6 +35,10 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => AlphaPickerComponent),
       multi: true,
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => AlphaPickerComponent)
     }
   ]
 })

--- a/src/lib/components/block/block.component.ts
+++ b/src/lib/components/block/block.component.ts
@@ -83,7 +83,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => BlockComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => BlockComponent),
+    },
   ]
 })
 export class BlockComponent extends ColorWrap {

--- a/src/lib/components/chrome/chrome.component.ts
+++ b/src/lib/components/chrome/chrome.component.ts
@@ -116,7 +116,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => ChromeComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => ChromeComponent),
+    },
   ]
 })
 export class ChromeComponent extends ColorWrap {

--- a/src/lib/components/circle/circle.component.ts
+++ b/src/lib/components/circle/circle.component.ts
@@ -61,7 +61,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => CircleComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => CircleComponent),
+    },
   ]
 })
 export class CircleComponent extends ColorWrap {

--- a/src/lib/components/compact/compact.component.ts
+++ b/src/lib/components/compact/compact.component.ts
@@ -51,7 +51,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => CompactComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => CompactComponent),
+    },
   ]
 })
 export class CompactComponent extends ColorWrap {

--- a/src/lib/components/github/github.component.ts
+++ b/src/lib/components/github/github.component.ts
@@ -88,7 +88,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => GithubComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => GithubComponent),
+    },
   ]
 })
 export class GithubComponent extends ColorWrap {

--- a/src/lib/components/hue/hue-picker.component.ts
+++ b/src/lib/components/hue/hue-picker.component.ts
@@ -30,7 +30,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => HuePickerComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => HuePickerComponent),
+    },
   ]
 })
 export class HuePickerComponent extends ColorWrap implements OnChanges {

--- a/src/lib/components/material/material.component.ts
+++ b/src/lib/components/material/material.component.ts
@@ -62,7 +62,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => MaterialComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => MaterialComponent),
+    },
   ]
 })
 export class MaterialComponent extends ColorWrap {

--- a/src/lib/components/photoshop/photoshop.component.ts
+++ b/src/lib/components/photoshop/photoshop.component.ts
@@ -122,7 +122,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => PhotoshopComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => PhotoshopComponent),
+    },
   ]
 })
 export class PhotoshopComponent extends ColorWrap {

--- a/src/lib/components/shade/shade-picker.component.ts
+++ b/src/lib/components/shade/shade-picker.component.ts
@@ -30,7 +30,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => ShadeSliderComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => ShadeSliderComponent),
+    },
   ]
 })
 export class ShadeSliderComponent extends ColorWrap implements OnChanges {

--- a/src/lib/components/sketch/sketch.component.ts
+++ b/src/lib/components/sketch/sketch.component.ts
@@ -130,7 +130,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => SketchComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => SketchComponent),
+    },
   ]
 })
 export class SketchComponent extends ColorWrap {

--- a/src/lib/components/slider/slider.component.ts
+++ b/src/lib/components/slider/slider.component.ts
@@ -38,7 +38,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => SliderComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => SliderComponent),
+    },
   ]
 })
 export class SliderComponent extends ColorWrap {

--- a/src/lib/components/swatches/swatches.component.ts
+++ b/src/lib/components/swatches/swatches.component.ts
@@ -61,7 +61,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => SwatchesComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => SwatchesComponent),
+    },
   ]
 })
 export class SwatchesComponent extends ColorWrap {

--- a/src/lib/components/twitter/twitter.component.ts
+++ b/src/lib/components/twitter/twitter.component.ts
@@ -130,7 +130,11 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => TwitterComponent),
       multi: true,
-    }
+    },
+    {
+      provide: ColorWrap,
+      useExisting: forwardRef(() => TwitterComponent),
+    },
   ]
 })
 export class TwitterComponent extends ColorWrap {


### PR DESCRIPTION
Reopen:

Allows injecting the color component instance with a common injection token. For instance, a directive that should work with any color component and should have access to the current color component instance. With the common injection token, the directive can inject any color component instance with one injection statement.