### PR TITLE
fix: Change peerDependencies into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng-packagr -p ./src/lib/package.json",
+    "build": "ng-packagr -p ./src/lib/package.json && cp README.md ./dist && cp LICENSE ./dist",
     "ghpages": "ng build --configuration production --no-progress",
     "test": "ng test --watch=false --code-coverage --browsers=ChromeCI",
     "test:watch": "ng test --browsers=ChromeCI",

--- a/src/lib/circle/package.json
+++ b/src/lib/circle/package.json
@@ -6,7 +6,7 @@
     "url": "git+https://github.com/scttcper/ngx-color.git"
   },
   "license": "MIT",
-  "peerDependencies": {
+  "dependencies": {
     "material-colors": "^1.2.6"
   },
   "ngPackage": {

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -3,10 +3,12 @@
   "name": "ngx-color",
   "version": "0.0.0-placeholder",
   "description": "A Collection of Color Pickers from Sketch, Photoshop, Chrome & more",
+  "dependencies": {
+    "@ctrl/tinycolor": "^3.4.0"
+  },
   "peerDependencies": {
     "@angular/core": ">=12.0.0-0",
-    "@angular/common": ">=12.0.0-0",
-    "@ctrl/tinycolor": "^3.4.0"
+    "@angular/common": ">=12.0.0-0"
   },
   "homepage": "https://github.com/scttcper/ngx-color",
   "repository": "scttcper/ngx-color",
@@ -15,6 +17,10 @@
     "lib": {
       "entryFile": "public_api.ts"
     },
+    "allowedNonPeerDependencies": [
+      "@ctrl/tinycolor",
+      "material-colors"
+    ],
     "dest": "../../dist"
   },
   "keywords": [

--- a/src/lib/swatches/package.json
+++ b/src/lib/swatches/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/scttcper/ngx-color.git"
   },
-  "peerDependencies": {
+  "dependencies": {
     "material-colors": "^1.2.6"
   },
   "ngPackage": {


### PR DESCRIPTION
@scttcper this PR fixes the last two remaining issues with the Angular 13 upgrade. The `peerDependencies` have been changed back into normal `dependencies`, and the `README.md` and `LICENSE` are added back into te package.

I ran into an `ng-packagr` issue with the relative `dest`  path we currently use in the configuration, which means I couldn't use the `assets` configuration property to directly copy assets into the package so resorted to using `cp . .` to get the job done.

fixes #362